### PR TITLE
feat: added styles for critical status

### DIFF
--- a/src/components/AnalysisResultStep/BloodTestSummary/styles.ts
+++ b/src/components/AnalysisResultStep/BloodTestSummary/styles.ts
@@ -52,5 +52,8 @@ export const PositionIndicator = styled(Box)<{ positionValue: number }>(
     '&.Low': {
       color: theme.palette.markerIndicatorColors.pointer.red,
     },
+    '&.Critical': {
+      color: theme.palette.baseColors.red[800],
+    },
   }),
 );

--- a/src/components/AnalysisResultStep/MarkerCardsTable/styles.ts
+++ b/src/components/AnalysisResultStep/MarkerCardsTable/styles.ts
@@ -67,6 +67,10 @@ export const MarkerCircle = styled(Box)(({ theme }) => ({
     backgroundColor: theme.palette?.baseColors?.red?.[400],
     border: `1px solid ${theme.palette?.baseColors?.red?.[50]}`,
   },
+  '&.Critical': {
+    color: theme.palette?.baseColors?.red?.[500],
+    border: `1px solid ${theme.palette?.baseColors?.red?.[50]}`,
+  },
 }));
 
 export const MarkerName = styled(Typography)(({ theme }) => ({
@@ -107,6 +111,11 @@ export const StatusBadge = styled(Typography)(({ theme }) => ({
     color: theme.palette.markerIndicatorColors.text.red,
     backgroundColor: theme.palette.surface.cardBackground.cardBgPastelRed,
     border: `1px solid ${theme.palette.border.markerInterpretation.borderRed}`,
+  },
+  '&.Critical': {
+    color: theme.palette.baseColors.red[800],
+    backgroundColor: theme.palette.baseColors.red[200],
+    border: `1px solid ${theme.palette.baseColors.red[300]}`,
   },
 }));
 

--- a/src/components/Marker/styles.ts
+++ b/src/components/Marker/styles.ts
@@ -206,6 +206,10 @@ export const MarkerCircle = styled(Box)(({ theme }) => ({
     backgroundColor: theme.palette?.baseColors?.red?.[400],
     border: `1px solid ${theme.palette?.baseColors?.green?.[50]}`,
   },
+  '&.Critical': {
+    backgroundColor: theme.palette?.baseColors?.red?.[500],
+    border: `1px solid ${theme.palette?.baseColors?.green?.[50]}`,
+  },
 }));
 
 export const MarkerText = styled(Typography)(({ theme }) => ({
@@ -254,6 +258,11 @@ export const MarkerInterpretation = styled(Box)(({ theme }) => ({
     color: theme.palette.markerIndicatorColors.text.red,
     backgroundColor: theme.palette.surface.cardBackground.cardBgPastelRed,
     border: `1px solid ${theme.palette.border.markerInterpretation.borderRed}`,
+  },
+  '&.Critical': {
+    color: theme.palette.baseColors.red[800],
+    backgroundColor: theme.palette.baseColors.red[200],
+    border: `1px solid ${theme.palette.baseColors.red[300]}`,
   },
 }));
 

--- a/src/constants/marker.ts
+++ b/src/constants/marker.ts
@@ -111,6 +111,7 @@ export const MARKER_STATUS = {
   HIGH: 'High',
   SLIGHTLY_LOW: 'Slightly Low',
   LOW: 'Low',
+  CRITICAL: 'Critical',
 } as const;
 
 export const MARKER_STATUS_CLASSES = {
@@ -119,4 +120,5 @@ export const MARKER_STATUS_CLASSES = {
   [MARKER_STATUS.HIGH]: 'High',
   [MARKER_STATUS.SLIGHTLY_LOW]: 'Slightly-Low',
   [MARKER_STATUS.LOW]: 'Low',
+  [MARKER_STATUS.CRITICAL]: 'Critical',
 } as const;


### PR DESCRIPTION
Added styles for critical status in marker table
<img width="1019" height="103" alt="image" src="https://github.com/user-attachments/assets/707da6de-7c71-416d-93e3-2e4ad613cd98" />
